### PR TITLE
Fix ConcurrentPriorityQueue ToArray bug

### DIFF
--- a/DataStructures/ConcurrentPriorityQueue.cs
+++ b/DataStructures/ConcurrentPriorityQueue.cs
@@ -115,7 +115,7 @@ namespace DataStructures
             try
             {
                 var array = new T[Count];
-                CopyTo(array, 0);
+                base.CopyTo(array, 0);
                 return array;
             }
             finally


### PR DESCRIPTION
`EnterReadLock()` was called twice via `CopyTo()` in `ToArray()`
Call `base.CopyTo()` instead
